### PR TITLE
Update create_stack_dash.py: Fixing issue where UI had to wait for stack creation to get Grafana link

### DIFF
--- a/jmeter-icap/scripts/create_stack_dash.py
+++ b/jmeter-icap/scripts/create_stack_dash.py
@@ -8,7 +8,10 @@ from dotenv import load_dotenv
 from aws_secrets import get_secret_value
 from threading import Thread
 from time import sleep
+import logging
+import sys
 
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 # Stacks are deleted duration + offset seconds after creation; should be set to 900.
 DELETE_TIME_OFFSET = 900
 # Interval between "time elapsed" messages sent to user; should be set to 600.

--- a/jmeter-icap/scripts/create_stack_dash.py
+++ b/jmeter-icap/scripts/create_stack_dash.py
@@ -20,6 +20,7 @@ class Config(object):
     BASEDIR = os.path.abspath(os.path.dirname(__file__))
     load_dotenv(os.path.join(BASEDIR, 'config.env'), override=True)
     try:
+        # these field names should not be changed as they correspond exactly to the names of create_stack's params.
         aws_profile_name = os.getenv("AWS_PROFILE_NAME")
         region = os.getenv("REGION")
         total_users = int(os.getenv("TOTAL_USERS"))
@@ -249,7 +250,8 @@ def main(config):
     create_stack_args = get_args_list(config, create_stack_options)
 
     print("Creating Load Generators...")
-    create_stack.Main.main(create_stack_args)
+    create_stack_thread = Thread(target=create_stack.Main.main(create_stack_args))
+    create_stack_thread.start()
 
     if config.preserve_stack:
         print("Stack will not be automatically deleted.")

--- a/jmeter-icap/scripts/create_stack_dash.py
+++ b/jmeter-icap/scripts/create_stack_dash.py
@@ -8,10 +8,7 @@ from dotenv import load_dotenv
 from aws_secrets import get_secret_value
 from threading import Thread
 from time import sleep
-import logging
-import sys
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 # Stacks are deleted duration + offset seconds after creation; should be set to 900.
 DELETE_TIME_OFFSET = 900
 # Interval between "time elapsed" messages sent to user; should be set to 600.


### PR DESCRIPTION
- Create_stack should now start as separate thread successfully, allowing UI to receive Grafana URL without waiting for stack creation to complete.